### PR TITLE
fix(solid-query): SSR fixes

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -89,10 +89,9 @@ export function createBaseQuery<
           if (!unsubscribe) {
             unsubscribe = createClientSubscriber(() => refetch())
           }
-
-          if (!state.isInitialLoading) {
-            resolve(state)
-          }
+        }
+        if (!state.isInitialLoading) {
+          resolve(state)
         }
       })
     },
@@ -129,8 +128,10 @@ export function createBaseQuery<
            * Do not refetch query on mount if query was fetched on server,
            * even if `staleTime` is not set.
            */
-          defaultedOptions.refetchOnMount = false
-
+          if (defaultedOptions.staleTime || !defaultedOptions.initialData) {
+            defaultedOptions.refetchOnMount = false
+          }
+          setState(observer.getOptimisticResult(defaultedOptions))
           unsubscribe = createClientSubscriber(() => refetch())
         }
       },
@@ -138,7 +139,7 @@ export function createBaseQuery<
   )
 
   onCleanup(() => {
-    if (!isServer && unsubscribe) {
+    if (unsubscribe) {
       unsubscribe()
       unsubscribe = null
     }


### PR DESCRIPTION
This PR fixes two issues:

1. If we just use SSR (no Streaming) with Solid Start, when the query is hydrated, The data is updated due to it being a part of the resource. But the state store will be in its initial state. Where stuff like isFetching will be true, dataUpdatedAt will be 0, etc. This happens because there is no reactivity on the server! So even though we update the state store in the server subscription handler. The state variable never updates on server rendered DOM elements. So after the query is hydrated we can safely update the store
2. The second issue will be noticed if we have two queries with the same key but one of them has initialData set. When the second query mounts, it will already have data set but it will still wait for the fetcher to resolve instead of deduping the data. 

This also was the reason why the unsubscribe function wasn't working correctly on the server. It is fixed now.

